### PR TITLE
Added `isUrl()` rule

### DIFF
--- a/src/rules/is_url.ts
+++ b/src/rules/is_url.ts
@@ -1,0 +1,14 @@
+import { invalid } from "../utils.ts";
+import { Validity } from "../types.ts";
+
+export function isUrl(value: any): Validity {
+  // From 
+  const expression =
+    /^(?:http(s)?:\/\/)?[\w.-]+(?:\.[\w\.-]+)+[\w\-\._~:/?#[\]@!\$&'\(\)\*\+,;=.]+$/g;
+
+  const regex = new RegExp(expression);
+
+  if (typeof value !== "string" || !regex.test(value.toLowerCase())) {
+    return invalid("isUrl", { value });
+  }
+}

--- a/src/rules/is_url.ts
+++ b/src/rules/is_url.ts
@@ -2,7 +2,7 @@ import { invalid } from "../utils.ts";
 import { Validity } from "../types.ts";
 
 export function isUrl(value: any): Validity {
-  // From 
+  // From
   const expression =
     /^(?:http(s)?:\/\/)?[\w.-]+(?:\.[\w\.-]+)+[\w\-\._~:/?#[\]@!\$&'\(\)\*\+,;=.]+$/g;
 

--- a/tests/rules/is_url.test.ts
+++ b/tests/rules/is_url.test.ts
@@ -15,12 +15,12 @@ Deno.test("rules.isUrl(0.1) should be invalid", () => {
 });
 
 Deno.test("rules.isUrl() with invalid urls should be invalid", () => {
-  const url = "test"
+  const url = "test";
   assertInvalid(isUrl(url), invalid("isUrl", { value: url }));
 });
 
 Deno.test("rules.isUrl() with invalid urls should be invalid", () => {
-  const url = "http:/test.com"
+  const url = "http:/test.com";
   assertInvalid(isUrl(url), invalid("isUrl", { value: url }));
 });
 

--- a/tests/rules/is_url.test.ts
+++ b/tests/rules/is_url.test.ts
@@ -1,0 +1,41 @@
+import { isUrl } from "../../src/rules/is_url.ts";
+import { invalid } from "../../src/utils.ts";
+import { assertInvalid, assertValid } from "../utils.ts";
+
+Deno.test("rules.isUrl(null) should be invalid", () => {
+  assertInvalid(isUrl(null), invalid("isUrl", { value: null }));
+});
+
+Deno.test("rules.isUrl(undefined) should be invalid", () => {
+  assertInvalid(isUrl(undefined), invalid("isUrl", { value: undefined }));
+});
+
+Deno.test("rules.isUrl(0.1) should be invalid", () => {
+  assertInvalid(isUrl(0.1), invalid("isUrl", { value: 0.1 }));
+});
+
+Deno.test("rules.isUrl() with invalid urls should be invalid", () => {
+  const url = "test"
+  assertInvalid(isUrl(url), invalid("isUrl", { value: url }));
+});
+
+Deno.test("rules.isUrl() with invalid urls should be invalid", () => {
+  const url = "http:/test.com"
+  assertInvalid(isUrl(url), invalid("isUrl", { value: url }));
+});
+
+Deno.test("rules.isUrl() with valid urls should be valid", () => {
+  assertValid(isUrl("http://www.test.com"));
+});
+
+Deno.test("rules.isUrl() with valid urls should be valid", () => {
+  assertValid(isUrl("www.test.com"));
+});
+
+Deno.test("rules.isUrl() with valid urls should be valid", () => {
+  assertValid(isUrl("test.com"));
+});
+
+Deno.test("rules.isUrl() with valid urls should be valid", () => {
+  assertValid(isUrl("test.com/"));
+});


### PR DESCRIPTION
I wasn't able to convert the massive regexp rule from Laravel/Symfony into Validasaur, but this one will make any of the below urls valid : 

- test.com
- test.com/
- www.test.com
- http://www.test.com
- https://www.test.com