### PR TITLE
Add `notNaN()` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Validasaur is Deno validation library slightly inspired by Laravel Validation.
     - [`minNumber(minValue: number)`](#minnumberminvalue-number)
     - [`notIn(disallowedValues: PrimitiveTypes[])`](#notindisallowedvalues-primitivetypes)
     - [`notNull`](#notnull)
+    - [`notNaN`](#notnan)
     - [`nullable`](#nullable)
     - [`numberBetween(minValue: number, maxValue: number)`](#numberbetweenminvalue-number-maxvalue-number)
     - [`requiredIf(field: string, fieldValue: any)`](#requirediffield-string-fieldvalue-any)
@@ -462,6 +463,9 @@ Value under this field must be valid email address.
 
 #### `isFloat`
 
+> **Warning**
+> This does not check for `NaN`. Please use `notNaN` as well.
+
 Value under this field must be a float number.
 
 * Invalid values: `"0.1"`, `[]`, `0`, `1`, `123`, etc.
@@ -487,6 +491,9 @@ const [ passes, errors ] = await validate({
 
 #### `isInt`
 
+> **Warning**
+> This does not check for `NaN`. Please use `notNaN` as well.
+
 Value under this field must be an integer.
 
 * Invalid values: `0.5`, `"123"`, etc.
@@ -508,12 +515,18 @@ Value under this field must be valid IPv6.
 
 #### `isNumber`
 
+> **Warning**
+> This does not check for `NaN`. Please use `notNaN` as well.
+
 Value under this field must be a float or an integer.
 
 * Invalid values: `"1"`, `"1.5"`, etc.
 * Valid values: `1`, `1.5`, etc.
 
 #### `isNumeric`
+
+> **Warning**
+> This does not check for `NaN`. Please use `notNaN` as well.
 
 Same as `asNumber`, but it allows numeric string.
 
@@ -587,6 +600,9 @@ const [ passes, errors ] = await validate({
 
 #### `maxNumber(maxValue: number)`
 
+> **Warning**
+> This does not check for `NaN`. Please use `notNaN` as well.
+
 Value under this field should be a number that is not higher than `maxValue`.
 
 Example:
@@ -622,6 +638,9 @@ const [ passes, errors ] = await validate({
 ```
 
 #### `minNumber(minValue: number)`
+
+> **Warning**
+> This does not check for `NaN`. Please use `notNaN` as well.
 
 Value under this field should be a number that is not lower than `minValue`.
 
@@ -662,6 +681,11 @@ const [ passes, errors ] = await validate({
 #### `notNull`
 
 Value under this field must not be `null`.
+
+#### `notNaN`
+
+Value under this field must not be `NaN`.
+
 
 #### `nullable`
 

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -21,6 +21,7 @@ export const defaultMessages: ValidationMessages = {
   minNumber: ":attr cannot be lower than :minValue",
   notIn: ":value is not allowed",
   notNull: ":value cannot be null",
+  notNaN: ":attr cannot be NaN",
   numberBetween: ":value must be between :minValue - :maxValue",
   required: ":attr is required",
   default: ":attr is invalid",

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -24,6 +24,7 @@ export * from "./rules/min_length.ts";
 export * from "./rules/min_number.ts";
 export * from "./rules/not_in.ts";
 export * from "./rules/not_null.ts";
+export * from "./rules/not_nan.ts";
 export * from "./rules/nullable.ts";
 export * from "./rules/number_between.ts";
 export * from "./rules/match.ts";

--- a/src/rules/not_nan.ts
+++ b/src/rules/not_nan.ts
@@ -1,0 +1,6 @@
+import type { Validity } from "../types.ts";
+import { invalid } from "../utils.ts";
+
+export function notNaN(value: any): Validity {
+  return isNaN(value) ? invalid("notNaN", { value }, true) : undefined;
+}

--- a/tests/rules/not_nan.test.ts
+++ b/tests/rules/not_nan.test.ts
@@ -1,0 +1,11 @@
+import { notNaN } from "../../src/rules/not_nan.ts";
+import { invalid } from "../../src/utils.ts";
+import { assertInvalid, assertValid } from "../utils.ts";
+
+Deno.test("rules.notNaN(NaN) should be invalid", () => {
+  assertInvalid(notNaN(NaN), invalid("notNaN", { value: NaN }, true));
+});
+
+Deno.test("rules.notNaN(0) should be valid", () => {
+  assertValid(notNaN(0));
+});


### PR DESCRIPTION
A `nonNaN` rule has been added since the existing rules like `isNumber`, `isFloat`, `isNumeric`, `minNumber`, `maxNumber` all pass when providing a `NaN` value. 

To provide backwards compatibility, the existing rules have not been changed.

Furthermore, the README has been changed to provide a notice that the above rules don't check for `NaN`.

Would fix issues like https://github.com/emsifa/validasaur/issues/33